### PR TITLE
start moving to toast 0.3.x, the new rust-based beta releases

### DIFF
--- a/new-toast-site/package.json
+++ b/new-toast-site/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "author": "alex strand <ajstrand@gmail.com> (@_alex_strand)",
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "dev": "yarn run build && yarn run serve",
     "serve": "npx serve public",
@@ -23,6 +24,7 @@
     "facepaint": "^1.2.1",
     "fs-extra": "^9.0.1",
     "globby": "^11.0.1",
+    "json5": "^2.1.3",
     "parse-numeric-range": "^1.2.0",
     "preact": "^10.5.4",
     "prism-react-renderer": "^1.1.1",
@@ -33,6 +35,7 @@
     "rehype-autolink-headings": "^4.0.0",
     "rehype-parse": "^7.0.1",
     "rehype-slug": "^3.0.0",
+    "styled-resume": "file:../styled-resume",
     "theme-ui": "^0.3.1",
     "toast": "^0.3.9",
     "unified": "^9.2.0"
@@ -52,6 +55,13 @@
     }
   },
   "snowpack": {
+    "exclude": [
+      "fetch-mdx-post-files.js",
+      "toast.js",
+      "rehype-prism-mdx.js",
+      "public",
+      ".tmp"
+    ],
     "installOptions": {
       "alias": {
         "react": "preact/compat",

--- a/new-toast-site/src/page-wrapper.js
+++ b/new-toast-site/src/page-wrapper.js
@@ -11,12 +11,12 @@ import { Flex } from "theme-ui";
 import Header from "./temp/Header.js";
 import Copyright from "./temp/Copyright.js";
 
-const StyledSummary = styled.summary`
+const StyledSummary = styled.default.summary`
   color: ${(props) => props.theme.colors.white};
   background-color: ${(props) => props.theme.colors.black};
 `;
 
-const StyledDetails = styled.details`
+const StyledDetails = styled.default.details`
   & black-lives {
     padding: 15px;
     width: fit-content;
@@ -49,7 +49,7 @@ const MetaDetails = ({ title, description }) => (
     ></script>
   </Helmet>
 );
-const GlobalStyles = styled(Global)`
+const GlobalStyles = styled.default(Global)`
   /* lora-regular - latin-ext_latin */
   @font-face {
     font-family: "Lora";

--- a/new-toast-site/src/pages/resume.js
+++ b/new-toast-site/src/pages/resume.js
@@ -4,7 +4,7 @@ import { jsx } from "@emotion/core";
 const maxWidth = "800px";
 import styled from "@emotion/styled";
 //import ResumeContent from "../customComponents/ResumeContent";
-import { StyledResume } from "styled-resume";
+// import { StyledResume } from "styled-resume";
 
 const ResumeContainer = styled.div`
   @media screen {
@@ -21,7 +21,7 @@ const ResumeContainer = styled.div`
   }
 `;
 
-console.log(StyledResume);
+// console.log(StyledResume);
 
 const Resume = (props) => {
   //const { data, location } = props;
@@ -37,7 +37,7 @@ const Resume = (props) => {
   );
   return (
     <Fragment>
-      <StyledResume />
+      {/* <StyledResume /> */}
       <p> You can download a copy of my resume {resumeLink}</p>
       <p>Resume design forked from {DesignAttribution}</p>
       {/* <ResumeContainer>

--- a/new-toast-site/src/pages/styles.js
+++ b/new-toast-site/src/pages/styles.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
-import StyleGuideComponent from "../StyleGuideComponent.js";
+import StyleGuideComponent from "../temp/StyleGuideComponent.js";
 const StylesDemo = () => <StyleGuideComponent />;
 
 export default StylesDemo;

--- a/new-toast-site/src/temp/Copyright.js
+++ b/new-toast-site/src/temp/Copyright.js
@@ -2,7 +2,7 @@
 import { jsx } from "@emotion/core";
 import styled from "@emotion/styled";
 
-const SmallText = styled.p`
+const SmallText = styled.default.p`
   margin-bottom: 5px;
   font-size: 9px;
   display: inline-flex;

--- a/new-toast-site/src/temp/Header.js
+++ b/new-toast-site/src/temp/Header.js
@@ -4,7 +4,7 @@ import { jsx } from "@emotion/core";
 import styled from "@emotion/styled";
 import SiteNav from "./SiteNav.js";
 
-const Header = styled.header`
+const Header = styled.default.header`
   @media screen {
     display: flex;
     flex-direction: column;

--- a/new-toast-site/src/temp/SiteLinks.js
+++ b/new-toast-site/src/temp/SiteLinks.js
@@ -2,9 +2,9 @@
 /** @jsxFrag Fragment */
 import { Fragment, h } from "preact";
 import styled from "@emotion/styled";
-import { SiteLink } from "./componentsList";
+import { SiteLink } from "./componentsList.js";
 
-const PageLink = styled(SiteLink)`
+const PageLink = styled.default(SiteLink)`
   margin: 0 1em 0 1em;
 `;
 const nav = [

--- a/new-toast-site/src/temp/SocialProfiles.js
+++ b/new-toast-site/src/temp/SocialProfiles.js
@@ -5,7 +5,7 @@ import { h, Fragment } from "preact";
 import styled from "@emotion/styled";
 import { GitHub, Twitter, Linkedin } from "react-feather";
 
-const StyledAnchorTag = styled.a`
+const StyledAnchorTag = styled.default.a`
   margin: 0.5em;
   color: ${(props) => props.theme.colors.text};
 `;

--- a/new-toast-site/src/temp/componentsList.js
+++ b/new-toast-site/src/temp/componentsList.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import styled from "@emotion/styled";
 import { Flex } from "theme-ui";
-export const OverflowYScrollContainer = styled(Flex)`
+export const OverflowYScrollContainer = styled.default(Flex)`
   padding: 0.5em;
   flex-direction: column;
   height: 100%;
@@ -13,11 +13,11 @@ export const OverflowYScrollContainer = styled(Flex)`
   }
 `;
 
-export const SiteLink = styled.a`
+export const SiteLink = styled.default.a`
   color: ${(props) => props.theme.colors.text};
 `;
 
-export const ListItem = styled(Flex)`
+export const ListItem = styled.default(Flex)`
   padding: 0.5em;
   flex-direction: column;
   width: 100%;

--- a/new-toast-site/toast.js
+++ b/new-toast-site/toast.js
@@ -1,60 +1,58 @@
-const { promises: fs } = require("fs-extra");
-const fse = require("fs-extra");
-const path = require("path");
-const MDXPostsSource = require("./fetch-mdx-post-files");
+import { promises as fs } from "fs-extra";
+import fse from "fs-extra";
+import path from "path";
+import * as MDXPostsSource from "./fetch-mdx-post-files.js";
 
-exports.sourceData = async ({ withCache, createPage }) => {
-  return Promise.all([
-    withCache("mdx-posts", MDXPostsSource.sourceData({ createPage })),
-  ]);
+export const sourceData = async ({ createPage }) => {
+  return Promise.all([MDXPostsSource.sourceData({ createPage })]);
 };
 
-exports.prepData = async ({ cacheDir, publicDir }) => {
-  // have to make sure the directory we want to write in exists
-  // We can probably avoid this by offering some kind of "non-filesystem"-based
-  // API for adding data to paths
-  await fse.mkdir(path.resolve(publicDir, "src/pages"), { recursive: true });
+// export const prepData = async ({ cacheDir, publicDir }) => {
+//   // have to make sure the directory we want to write in exists
+//   // We can probably avoid this by offering some kind of "non-filesystem"-based
+//   // API for adding data to paths
+//   await fse.mkdir(path.resolve(publicDir, "src/pages"), { recursive: true });
 
-  // prep page data for index and post pages
-  const mdxPostsData = require(path.resolve(cacheDir, "mdx-posts.json"));
+//   // prep page data for index and post pages
+//   const mdxPostsData = require(path.resolve(cacheDir, "mdx-posts.json"));
 
-  const allPostsData = mdxPostsData.map(({ title, date, slug, tags }) => ({
-    title,
-    updatedAt: date,
-    slug,
-    tags,
-    contentType: "blog-post",
-  }));
+//   const allPostsData = mdxPostsData.map(({ title, date, slug, tags }) => ({
+//     title,
+//     updatedAt: date,
+//     slug,
+//     tags,
+//     contentType: "blog-post",
+//   }));
 
-  await fse.copy(
-    path.resolve("content/resume/alex_strand_resume_latest.pdf"),
-    `${publicDir}/alex_strand_resume.pdf`
-  );
+//   await fse.copy(
+//     path.resolve("content/resume/alex_strand_resume_latest.pdf"),
+//     `${publicDir}/alex_strand_resume.pdf`
+//   );
 
-  await fse.copy(path.resolve("content/assets/me.jpg"), `${publicDir}/me.jpg`);
+//   await fse.copy(path.resolve("content/assets/me.jpg"), `${publicDir}/me.jpg`);
 
-  await fse.copy(path.resolve("src/fonts"), `${publicDir}/src/fonts`);
+//   await fse.copy(path.resolve("src/fonts"), `${publicDir}/src/fonts`);
 
-  await fse.writeFile(
-    path.resolve(publicDir, "src/pages/garden.json"),
-    JSON.stringify({ posts: allPostsData })
-  );
+//   await fse.writeFile(
+//     path.resolve(publicDir, "src/pages/garden.json"),
+//     JSON.stringify({ posts: allPostsData })
+//   );
 
-  // index.html
+//   // index.html
 
-  const curatedPostsData = allPostsData
-    .sort((b, a) => {
-      const da = new Date(a.updatedAt).getTime();
-      const db = new Date(b.updatedAt).getTime();
-      if (da < db) return -1;
-      if (da === db) return 0;
-      if (da > db) return 1;
-    })
-    .filter(({ contentType }) => contentType === "blog-post")
-    .slice(0, 5);
+//   const curatedPostsData = allPostsData
+//     .sort((b, a) => {
+//       const da = new Date(a.updatedAt).getTime();
+//       const db = new Date(b.updatedAt).getTime();
+//       if (da < db) return -1;
+//       if (da === db) return 0;
+//       if (da > db) return 1;
+//     })
+//     .filter(({ contentType }) => contentType === "blog-post")
+//     .slice(0, 5);
 
-  await fse.writeFile(
-    path.resolve(publicDir, "src/pages/index.json"),
-    JSON.stringify({ posts: curatedPostsData })
-  );
-};
+//   await fse.writeFile(
+//     path.resolve(publicDir, "src/pages/index.json"),
+//     JSON.stringify({ posts: curatedPostsData })
+//   );
+// };

--- a/new-toast-site/yarn.lock
+++ b/new-toast-site/yarn.lock
@@ -875,7 +875,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
@@ -1696,6 +1696,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/lodash@^4.14.161":
+  version "4.14.161"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.161.tgz#a21ca0777dabc6e4f44f3d07f37b765f54188b18"
+  integrity sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==
+
 "@types/mdast@^3.0.0":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.3.tgz#2d7d671b1cd1ea3deb306ea75036c2a0407d2deb"
@@ -2050,6 +2055,13 @@ babel-plugin-macros@^2.0.0:
     "@babel/runtime" "^7.7.2"
     cosmiconfig "^6.0.0"
     resolve "^1.12.0"
+
+babel-plugin-polished@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polished/-/babel-plugin-polished-1.1.0.tgz#7f6902ab8e9c20fc14cb53d596dd858880e357d3"
+  integrity sha1-f2kCq46cIPwUy1PVlt2FiIDjV9M=
+  dependencies:
+    polished "^1.0.0"
 
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
@@ -2480,6 +2492,11 @@ core-js-pure@^3.0.0:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
   integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
+
+core-js@^3.6.5:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
+  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -3931,7 +3948,7 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@^2.1.2:
+json5@^2.1.2, json5@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
   integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
@@ -4827,6 +4844,18 @@ please-upgrade-node@^3.2.0:
   dependencies:
     semver-compare "^1.0.0"
 
+polished@^1.0.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-1.9.3.tgz#d61b8a0c4624efe31e2583ff24a358932b6b75e1"
+  integrity sha512-4NmSD7fMFlM8roNxs7YXPv7UFRbYzb0gufR5zBxJLRzY54+zFsavxBo6zsQzP9ep6Hh3pC2pTyrpSTBEaB6IkQ==
+
+polished@^3.6.7:
+  version "3.6.7"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-3.6.7.tgz#44cbd0047f3187d83db0c479ef0c7d5583af5fb6"
+  integrity sha512-b4OViUOihwV0icb9PHmWbR+vPqaSzSAEbgLskvb7ANPATVXGiYv/TQFHQo65S53WU9i5EQ1I03YDOJW7K0bmYg==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+
 preact-render-to-string@^5.1.10:
   version "5.1.10"
   resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-5.1.10.tgz#cce03d73b166c550148af9dedc9e06fdf6820f8a"
@@ -5067,7 +5096,7 @@ regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.1.tgz#cad92ad8e6b591773485fbe05a485caf4f457e6f"
   integrity sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==
 
-regenerator-runtime@^0.13.4:
+regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
   version "0.13.7"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
   integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
@@ -5699,6 +5728,16 @@ style-to-object@^0.3.0:
   integrity sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==
   dependencies:
     inline-style-parser "0.1.1"
+
+"styled-resume@file:../styled-resume":
+  version "0.0.1"
+  dependencies:
+    "@types/lodash" "^4.14.161"
+    babel-plugin-polished "^1.1.0"
+    core-js "^3.6.5"
+    polished "^3.6.7"
+    prop-types "^15.7.2"
+    regenerator-runtime "^0.13.7"
 
 styled-system@^5.1.5:
   version "5.1.5"


### PR DESCRIPTION
This PR makes a bunch of changes to bring the old toast site in line with the new toast release. It is not finished but I'll use comments to point out the changes that I made here.

There are two outstanding issues before this can be merged:

* a context issue in theme-ui. I believe this to be a similar issue to one I encountered with emotion when converting my own site. the reason was that emotion was requiring a commonjs verison of Preact while my application was requiring the esm version. My personal approach to that was to temporarily fork emotion until they release mjs support in v11
* styled-resume needs some changes or a patch as well to expose imports and such in esm fashion. I'm less familiar with the TS build system, so might need to do some research on what to do here. (something I'll need to figure out for the Toast docs anyway I think)

#### notes

I put styled-resume in `../styled-resume` and yarn installed it via a file dependency to avoid yarn link issues. This isn't super important and could be done in a few ways. I found this the easiest way tonight.